### PR TITLE
Remove develop branch references from workflows

### DIFF
--- a/.github/issue-branch.yml
+++ b/.github/issue-branch.yml
@@ -1,22 +1,22 @@
-defaultBranch: 'develop'
+defaultBranch: 'main'
 branchName: '${issue.number}:${issue.title,}'
 mode: auto
 gitSafeReplacementChar: '-'
 branches:
   - label : feature
     prefix: feature/
-    name: develop
-    prTarget: develop
+    name: main
+    prTarget: main
     skip: false
   - label : bug
     prefix: bugfix/
-    name: develop
-    prTarget: develop
+    name: main
+    prTarget: main
     skip: false
   - label : critical
     prefix: hotfix/
-    name: master
-    prTarget: master
+    name: main
+    prTarget: main
     skip: false
   - label : '*'
     skip: true

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, edited, synchronize, reopened]
-    branches: [main, develop]
+    branches: [main]
 
   workflow_run:
     workflows: [Create Prerelease, Create Release]

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -8,7 +8,7 @@ on:
           How to set the version:
           - explicit: set to a specific value (e.g., 1.3-alpha)
           - bump: bump major/minor/patch from current SimpleVersion and apply optional prerelease
-          - auto: policy-based (develop->next minor -alpha; hotfix/*->next patch -alpha; main/vX.Y->stable)
+          - auto: policy-based (main/vX.Y->stable; hotfix/*->next patch -alpha; feature branches->next minor -alpha)
         type: choice
         options: [auto, bump, explicit]
         default: auto

--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["Run Tests"]
     types:     [completed]
-    branches:  [main, develop]
+    branches:  [main]
 
 permissions:
   contents: read

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,11 +4,11 @@ on:
   workflow_run:
     workflows: [Create Release]
     types: [requested]
-    branches: [main, develop]        
+    branches: [main]
   workflow_dispatch:
   pull_request:
     types: [opened, edited, synchronize, reopened]
-    branches: [main, develop]
+    branches: [main]
 
 permissions:
   contents: read
@@ -24,19 +24,22 @@ jobs:
       - id: set_branch
         shell: bash
         run: |
-          # 1. Pick the raw branch/ref for each trigger type
+          # Pick the ref to test for each trigger type.
+          # For pull_request, test the PR head SHA (the incoming changes),
+          # not the base branch. Using the SHA is deterministic even if
+          # the PR branch is later force-pushed.
           if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            RAW='${{ github.event.workflow_run.head_branch }}'   
+            RAW='${{ github.event.workflow_run.head_sha }}'
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            RAW='${{ github.event.pull_request.base.ref }}'       
-          else                                                    
-            RAW='${{ github.ref }}'                                
+            RAW='${{ github.event.pull_request.head.sha }}'
+          else
+            RAW='${{ github.ref }}'
           fi
 
-          # 2. Strip the refs/heads/ prefix if present
+          # Strip the refs/heads/ prefix if present (only relevant for the push/dispatch fallback)
           CLEAN="${RAW#refs/heads/}"
 
-          echo "Detected branch: $CLEAN"
+          echo "Detected ref: $CLEAN"
           echo "branch_name=$CLEAN" >> "$GITHUB_OUTPUT"
 
   test:


### PR DESCRIPTION
Part of trunk-based migration. No develop merge needed (0 commits ahead).

develop SHA for rollback: c60344acb215104847e5c09fa05cca827121721b