### PR TITLE
Remove stale develop status badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,6 @@ for more details.
 
 | Branch     | Action                                                                                                                                                                                                                      |
 |------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `develop`  | [![Build status](https://github.com/Stillpoint-Software/Hyperbee.Collections/actions/workflows/pack_publish.yml/badge.svg?branch=develop)](https://github.com/Stillpoint-Software/Hyperbee.Collections/actions/workflows/pack_publish.yml)  |
 | `main`     | [![Build status](https://github.com/Stillpoint-Software/Hyperbee.Collections/actions/workflows/pack_publish.yml/badge.svg)](https://github.com/Stillpoint-Software/Hyperbee.Collections/actions/workflows/pack_publish.yml)                 |
 
 


### PR DESCRIPTION
Follow-up to trunk-based migration — the develop branch is gone, the badge row should be too.