### PR TITLE
Move local-jekyll.md out of docs/site/ to docs/

### DIFF
--- a/docs/local-jekyll.md
+++ b/docs/local-jekyll.md
@@ -1,6 +1,3 @@
----
-render_with_liquid: false
----
 # Running Jekyll Docs Locally (Docker)
 
 Reusable recipe for previewing `just-the-docs` / GitHub Pages sites locally


### PR DESCRIPTION
Fixes Pages build failure: Jekyll 3 has no per-file Liquid disable, and the file documents Liquid syntax.